### PR TITLE
Add ImageJ Macro to the list of languages.

### DIFF
--- a/lib/linguist/languages.yml
+++ b/lib/linguist/languages.yml
@@ -2369,6 +2369,15 @@ Ignore List:
   codemirror_mode: shell
   codemirror_mime_type: text/x-sh
   language_id: 74444240
+ImageJ Macro:
+  type: programing
+  color: "#99AAFF"
+  aliases:
+  - ijm
+  extensions:
+  - ".ijm"
+  ace_mode: text
+  tm_scope: none
 Inform 7:
   type: programming
   wrap: true


### PR DESCRIPTION
Add ImageJ Macro Language

## Description
I am adding the ImageJ Macro language widely used by scientists to handle images, particularly microscopy data.
I chose color: "#99AAFF# from the ImageJ Macro web documentation. It did not appear elsewhere in the list.
I am confident of the extension and that it is a programming language. The rest is a guess at this point.

## Checklist:
- [x] **I am adding a new language.**
  - [x] The extension of the new language is used in hundreds of repositories on GitHub.com.
    - Search results for each extension:
      <!-- Replace FOOBAR with the new extension, and KEYWORDS with keywords unique to the language. Repeat for each extension added. -->
      -  https://github.com/search?utf8=%E2%9C%93&type=Code&ref=searchresults&q=extension%3Aijm+ImageJ+NOT+nothack
  - [ ] I have included a real-world usage sample for all extensions added in this PR:
    - Sample source(s):
      - [URL to each sample source, if applicable]
    - Sample license(s):
  <!-- Update the Lightshow URLs below to show the grammar in action if you included one. -->
  - [ ] I have included a syntax highlighting grammar: https://github-lightshow.herokuapp.com/
  - [ ] I have updated the heuristics to distinguish my language from others using the same extension.

